### PR TITLE
Fix issue with Google Docs in Google Drive client

### DIFF
--- a/app/clients/google-drive/database.js
+++ b/app/clients/google-drive/database.js
@@ -264,6 +264,17 @@ const database = {
       return await get(this.tokenKey);
     };
 
+    this.getGoogleDocFileId = async (path) => {
+      const fileId = await this.getByPath(path);
+      if (fileId) {
+        const file = await this.get(fileId);
+        if (file && file.mimeType === "application/vnd.google-apps.document") {
+          return fileId;
+        }
+      }
+      return null;
+    };
+
     return this;
   },
 };

--- a/app/clients/google-drive/init.js
+++ b/app/clients/google-drive/init.js
@@ -1,8 +1,3 @@
-// IMPORTANT:
-//
-// If you make changes to this you will need to run sudo stop blot
-// && sudo start blot when you deploy. Simply restarting won't work.
-
 const debug = require("debug")("blot:clients:google-drive");
 const clfdate = require("helper/clfdate");
 const database = require("./database");

--- a/app/clients/google-drive/remove.js
+++ b/app/clients/google-drive/remove.js
@@ -8,11 +8,15 @@ module.exports = async function remove(blogID, path, callback) {
   const prefix = () => clfdate() + " Google Drive:";
   try {
     const { drive, account } = await createDriveClient(blogID);
-    const { getByPath } = database.folder(account.folderId);
+    const { getByPath, getGoogleDocFileId } = database.folder(account.folderId);
 
     console.log(prefix(), "Looking up fileId for", path);
 
-    const fileId = await getByPath(path);
+    let fileId = await getByPath(path);
+
+    if (!fileId) {
+      fileId = await getGoogleDocFileId(path);
+    }
 
     if (fileId) {
       console.log(prefix(), "Removing", fileId, "from API");

--- a/app/clients/google-drive/util/download.js
+++ b/app/clients/google-drive/util/download.js
@@ -40,7 +40,7 @@ module.exports = async (blogID, drive, path, file) => {
 
       // if the file is a google doc, then add the gdoc extension to pathOnBlot
       if (mimeType === "application/vnd.google-apps.document") {
-        console.log('we are here! with google doc');
+        pathOnBlot += ".gdoc";
         const res = await drive.files.export(
           {
             fileId: id,


### PR DESCRIPTION
Add support for handling Google Docs with the `.gdoc` extension in various Google Drive client functions.

* **Database Module**: Add `getGoogleDocFileId` function to retrieve the file ID of a Google Doc by its path. Modify the `folder` function to include the new `getGoogleDocFileId` function.
* **Remove Function**: Update the `remove` function to handle Google Docs with the `.gdoc` extension by using the new `getGoogleDocFileId` function.
* **Download Function**: Update the `download` function to handle Google Docs with the `.gdoc` extension by appending `.gdoc` to the path.

