### PR TITLE
Refactor site build to include documentation and dashboard views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build documentation and dashboard views
+        run: |
+          docker run --rm \
+            ghcr.io/${{ github.repository_owner }}/blot:test-${{ github.sha }} \
+            sh -c "npm run build:documentation && npm run build:dashboard"
+
       - name: Test
         env:
           BLOT_STRIPE_KEY: ${{ secrets.BLOT_STRIPE_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,20 @@ COPY ./tests ./tests
 # replaced with a better solution in the future
 COPY .git .git
 
-## Stage 5 (default, production)
+## Stage 5 (documentation and dashboard build)
+# This stage builds the documentation and dashboard views
+FROM source as docs-dashboard
+
+WORKDIR /usr/src/app
+
+# Copy the documentation and dashboard directories
+COPY ./app/documentation ./app/documentation
+COPY ./app/dashboard ./app/dashboard
+
+# Build the documentation and dashboard views
+RUN npm run build:documentation && npm run build:dashboard
+
+## Stage 6 (default, production)
 # The final production stage
 FROM source as prod
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,14 @@ services:
       - ./scripts:/usr/src/app/scripts
       - ./todo.txt:/usr/src/app/todo.txt
       - ./config:/usr/src/app/config
+      - ./app/documentation:/usr/src/app/app/documentation
+      - ./app/dashboard:/usr/src/app/app/dashboard
     # this is needed so the webhook relay can invoke the request 
     # inside docker, resolving the host to the correct IP
     extra_hosts:
       - "${BLOT_HOST}:${HOST_IP}"
-    command: npx nodemon /usr/src/app/app/local.js --watch /usr/src/app/app -e js,html,css --ignore /usr/src/app/app/documentation/data --ignore /usr/src/app/app/documentation/output --ignore /usr/src/app/app/views  --ignore /usr/src/app/app/clients/*/views
+    command: >
+      sh -c "npm run build:documentation && npm run build:dashboard && npx nodemon /usr/src/app/app/local.js --watch /usr/src/app/app -e js,html,css --ignore /usr/src/app/app/documentation/data --ignore /usr/src/app/app/documentation/output --ignore /usr/src/app/app/views  --ignore /usr/src/app/app/clients/*/views"
 
   redis:
     image: "redis:alpine"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -25,5 +25,7 @@ services:
       - ../notes:/usr/src/app/notes
       - ../todo.txt:/usr/src/app/todo.txt
       - ../.git:/usr/src/app/.git
+      - ../app/documentation:/usr/src/app/app/documentation
+      - ../app/dashboard:/usr/src/app/app/dashboard
     command: >
-      sh -c "rm -rf /usr/src/app/data && mkdir /usr/src/app/data && node tests $TEST_PATH"
+      sh -c "rm -rf /usr/src/app/data && mkdir /usr/src/app/data && npm run build:documentation && npm run build:dashboard && node tests $TEST_PATH"


### PR DESCRIPTION
Refactor the site build to be part of the Docker stage, copying in the git repo, building entire documentation and dashboard views, and handling development mode.

* **Dockerfile**
  - Add a new stage to build the documentation and dashboard views.
  - Copy the `app/documentation` and `app/dashboard` directories into the Docker image.
  - Add a command to build the documentation and dashboard views.

* **.github/workflows/ci.yml**
  - Add a step to build the documentation and dashboard views.
  - Ensure the step runs after the Docker build step.

* **docker-compose.yml**
  - Add a volume to mount the `app/documentation` and `app/dashboard` directories.
  - Add a command to build the documentation and dashboard views in the `node-app` service.

* **tests/docker-compose.yml**
  - Add a volume to mount the `app/documentation` and `app/dashboard` directories.
  - Add a command to build the documentation and dashboard views in the `tests` service.

