### PR TITLE
Make it possible to embed audio

### DIFF
--- a/app/blog/render/main.js
+++ b/app/blog/render/main.js
@@ -5,6 +5,13 @@ var pandoc = require("pandoc"); // Pca3e
 var ERROR = require("./error");
 var OVERFLOW = "Maximum call stack size exceeded";
 
+// Function to handle !Audio syntax for embedding audio
+function embedAudio(content) {
+  return content.replace(/!\[Audio\]\((.*?)\)/g, function (match, p1) {
+    return `<audio controls><source src="${p1}" type="audio/mpeg">Your browser does not support the audio element.</audio>`;
+  });
+}
+
 // This function basically wraps mustache
 // and gives me some nice error messages...
 module.exports = function render(content, locals, partials) {
@@ -32,6 +39,9 @@ module.exports = function render(content, locals, partials) {
       throw ERROR.BAD_LOCALS();
     }
   }
+
+  // Call the embedAudio function to handle !Audio syntax
+  output = embedAudio(output);
 
   return output;
 };

--- a/app/blog/static/audio-player.css
+++ b/app/blog/static/audio-player.css
@@ -1,0 +1,50 @@
+.audio-player {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 10px;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+}
+
+.audio-player audio {
+  display: none;
+}
+
+.audio-player .play-button,
+.audio-player .pause-button {
+  cursor: pointer;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.audio-player .pause-button {
+  display: none;
+}
+
+.audio-player .progress-container {
+  flex-grow: 1;
+  height: 5px;
+  background-color: #ddd;
+  border-radius: 5px;
+  margin: 0 10px;
+  overflow: hidden;
+}
+
+.audio-player .progress-bar {
+  height: 100%;
+  background-color: #007bff;
+  width: 0;
+}

--- a/app/blog/static/audio-player.js
+++ b/app/blog/static/audio-player.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var audioPlayers = document.querySelectorAll(".audio-player");
+
+  audioPlayers.forEach(function (player) {
+    var audio = player.querySelector("audio");
+    var playButton = player.querySelector(".play-button");
+    var pauseButton = player.querySelector(".pause-button");
+    var progressBar = player.querySelector(".progress-bar");
+
+    playButton.addEventListener("click", function () {
+      audio.play();
+      playButton.style.display = "none";
+      pauseButton.style.display = "inline-block";
+    });
+
+    pauseButton.addEventListener("click", function () {
+      audio.pause();
+      playButton.style.display = "inline-block";
+      pauseButton.style.display = "none";
+    });
+
+    audio.addEventListener("timeupdate", function () {
+      var progress = (audio.currentTime / audio.duration) * 100;
+      progressBar.style.width = progress + "%";
+    });
+  });
+});

--- a/app/blog/views/partials/audio-player.html
+++ b/app/blog/views/partials/audio-player.html
@@ -1,0 +1,8 @@
+<div class="audio-player">
+  <audio src="{{{path}}}" controls></audio>
+  <button class="play-button">Play</button>
+  <button class="pause-button">Pause</button>
+  <div class="progress-container">
+    <div class="progress-bar"></div>
+  </div>
+</div>

--- a/app/dashboard/site/import/helper/replace_embeds.js
+++ b/app/dashboard/site/import/helper/replace_embeds.js
@@ -1,4 +1,7 @@
-module.exports = function replaceEmbeds(html, callback) {
+var cheerio = require("cheerio");
+var parse = require("url").parse;
+
+function replaceEmbeds(html, callback) {
   var $ = cheerio.load(html, { decodeEntities: false });
 
   $("iframe").each(function () {
@@ -18,5 +21,19 @@ module.exports = function replaceEmbeds(html, callback) {
     }
   });
 
+  $("audio").each(function () {
+    var src = $(this).attr("src");
+    var audio = "";
+
+    if (src) {
+      audio = parse(src).pathname;
+      audio = audio.slice(audio.lastIndexOf("/") + 1);
+
+      $(this).replaceWith("<p>![Audio](" + audio + ")</p>");
+    }
+  });
+
   return callback($.html());
-};
+}
+
+module.exports = replaceEmbeds;


### PR DESCRIPTION
Add functionality to embed audio using the `!Audio` syntax.

* **Replace Embeds**: Modify `app/dashboard/site/import/helper/replace_embeds.js` to handle `!Audio` syntax for embedding audio.
* **Render Main**: Update `app/blog/render/main.js` to include a function that processes the `!Audio` syntax and embeds the audio player.
* **Audio Player**: Add `app/blog/static/audio-player.js` to handle the audio player functionality, including play/pause buttons and progress bar.
* **Audio Player CSS**: Add `app/blog/static/audio-player.css` to style the audio player elements.
* **Audio Player HTML**: Add `app/blog/views/partials/audio-player.html` to define the HTML structure of the audio player.

